### PR TITLE
Set missing property `pluginName` as "SimpleGrid"

### DIFF
--- a/simplegrid.js
+++ b/simplegrid.js
@@ -6,4 +6,8 @@ export default class SimpleGrid extends Plugin {
     static get requires() {
         return [ SimpleGridEditing, SimpleGridUI ];
     }
+    
+	static get pluginName() {
+		return 'SimpleGrid';
+	}
 }


### PR DESCRIPTION
Small change to make the plugin expose a `pluginName` as other regular plugins.

See e.g. https://github.com/ckeditor/ckeditor5-alignment/blob/194cb13db2538fb188755a37283359037ff3ac2d/src/alignment.js#L37 

Great work, thanks :) 